### PR TITLE
Update lib/package.json to include types in exports

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -23,7 +23,8 @@
   "exports": {
     ".": {
       "import": "./dist/plotly-vue-ts.es.js",
-      "require": "./dist/plotly-vue-ts.umd.js"
+      "require": "./dist/plotly-vue-ts.umd.js",
+      "types": "./dist/main.d.ts"
     }
   },
   "types": "./dist/main.d.ts",


### PR DESCRIPTION
I encountered an issue with the vue3-plotly module where TypeScript was unable to find the type declaration file. 
It appears this issue is due to the "exports" field in the package.json not including "types".
In this Pull Request, I propose adding "types" to the package.json to resolve this issue.